### PR TITLE
Fixed an error that would stop sphinx from deploying

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -25,4 +25,4 @@ jobs:
       if: github.ref == 'refs/heads/main'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: sphinx/build/html
+        publish_dir: sphinx/_build/html

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -6,9 +6,9 @@
 CCC Sphinx documentation
 ========================
 
-Add your content using ``reStructuredText`` syntax. See the
-`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
-documentation for details.
+.. Add your content using ``reStructuredText`` syntax. See the
+.. `reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
+.. documentation for details.
 
 
 .. toctree::


### PR DESCRIPTION
In the Deploy action, the file directory was sphinx/build/html, when it should have been sphinx/_build/html